### PR TITLE
fix `enabled_extensions` home manager config

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -70,10 +70,12 @@ in
             };
 
             "Plugins" = {
-              enabled_extensions = mkConfig (listOf str) [
-                "modal_update"
-                "plover_auto_reconnect_machine"
-              ];
+              enabled_extensions = lib.options.mkOption {
+                example = ["modal_update" "plover_auto_reconnect_machine"];
+                type = (listOf str);
+                default = null;
+                apply = xs: "[" + builtins.concatStringsSep ", " (map (x: "\"${x}\"") xs) + "]";
+              };
             };
 
             "System" = {


### PR DESCRIPTION
This PR fixes `enabled_extensions` to work with string list, which is not a valid entry as an ordinary ini file. Closes #235 if merged.
