### PR TITLE
Add `psutil` to `propagatedBuildInputs`

### DIFF
--- a/plover.nix
+++ b/plover.nix
@@ -7,6 +7,7 @@
   pyserial,
   qt6,
   requests-futures,
+  psutil,
   setuptools,
   wcwidth,
   xlib,
@@ -62,6 +63,7 @@ buildPythonPackage {
     requests-cache
     requests-futures
     plover-stroke
+    psutil
     rtf-tokenize
   ];
 


### PR DESCRIPTION
It seems like `psutil` is required on Wayland. I couldn't figure out the exact reason though..